### PR TITLE
Add config docs

### DIFF
--- a/prosepy/docs-ref-conceptual/config.md
+++ b/prosepy/docs-ref-conceptual/config.md
@@ -1,0 +1,58 @@
+---
+title: Configuring the Microsoft PROSE Code Accelerator SDK - Python
+ms.date: 10/22/2018
+ms.topic: conceptual
+ms.service: non-product-specific
+author: simmdan
+ms.author: dsimmons
+description: Learn how to configure settings for the PROSE Code Accelerator for Python.
+
+---
+
+# Configuring the Microsoft PROSE Code Accelerator SDK
+
+For most cases PROSE Code Accelerator has reasonable configuration defaults, but there are a few scenarios where you
+might want to override those default settings.  This is done with the `prose.codeaccelerator.config` variable which is a
+dictionary indexed by setting name.  You can examine or change the current value of any setting and future operations in
+the current python process will use the new setting.
+
+## Usage
+
+``` python
+import prose.codeaccelerator as cx
+
+cx.config["default_target"] = "pyspark"
+```
+
+## Configuration Settings
+
+User configurable settings include:
+
+- `default_target` : This sets the default code generation target value for newly created builders.  Most builders set
+  their target value to `"pandas"` by default, but if, for instance, you would like to change the target to `"pyspark"`
+  for all future builders created in this session, you can change this setting.
+
+- `ipython_display` : If this is set to the value `"repr"`, then even when Code Accelerator is used in an environment
+  that calls `ipython_display` (like a Jupyter notebook), it only renders the minimal output used for text-based
+  environments.  Otherwise, when in a notebook environment, Code Accelerator will return HTML-based output for a richer
+  user experience.
+
+- `telemetry_opt_out` : Set to `False` (default) instructs PROSE to send telemetry information for the purpose of
+  improving the product.  The data collected is not used to identify any person. Set to `True` instructs PROSE not to
+  send telemetry information.  NOTE: You may also set the environment variable `PROSE_TELEMETRY_OPTOUT` to any value,
+  and it's presence will cause this setting to be set to `True` and prevent telemetry information from being sent.
+
+## Persisting configuraiton changes
+
+If you want to change a setting for all future python processes, you will need to create/modify the PROSE configuration
+file found at `~/.config/prose/config.json`.  That file is read by PROSE when the Code Accelerator namespace is
+imported, so changing the file will not affect your current process--only future processes.
+
+### Example config.json file
+
+``` json
+{
+    "default_target": "pyspark",
+    "ipython_display": "repr"
+}
+```

--- a/prosepy/docs-ref-conceptual/config.md
+++ b/prosepy/docs-ref-conceptual/config.md
@@ -42,7 +42,7 @@ User configurable settings include:
   send telemetry information.  NOTE: You may also set the environment variable `PROSE_TELEMETRY_OPTOUT` to any value,
   and it's presence will cause this setting to be set to `True` and prevent telemetry information from being sent.
 
-## Persisting configuraiton changes
+## Persisting configuration changes
 
 If you want to change a setting for all future python processes, you will need to create/modify the PROSE configuration
 file found at `~/.config/prose/config.json`.  That file is read by PROSE when the Code Accelerator namespace is

--- a/prosepy/docs-ref-conceptual/fixdatatypes.md
+++ b/prosepy/docs-ref-conceptual/fixdatatypes.md
@@ -10,19 +10,17 @@ description: Learn how to use data type detection features in the PROSE Code Acc
 
 # Fix data types with the Microsoft PROSE Code Accelerator SDK
 
-One common pain point when working with data in Python is that values
-in columns in a data frame are often stored as strings whereas they should be numbers or dates. This prevents doing logical operations
-on those columns. The Microsoft PROSE Code Accelerator SDK includes the `DetectTypesBuilder` class, which will examine data and, if appropriate,
-produce code to transform the data to correct types.  While the underlying pandas and
-PySpark libraries in some cases have the ability to infer data types from
-strings, often the results are less than ideal: the set of supported
-formats is usually small. Further, these inference techniques usually fail
-completely if a column of data consists of values formatted in more than
-one way.
+One common pain point when working with data in Python is that values in columns in a data frame are often stored as
+strings whereas they should be numbers or dates. This prevents doing logical operations on those columns. The Microsoft
+PROSE Code Accelerator SDK includes the `DetectTypesBuilder` class, which will examine data and, if appropriate, produce
+code to transform the data to correct types.  While the underlying pandas and PySpark libraries in some cases have the
+ability to infer data types from strings, often the results are less than ideal: the set of supported formats is usually
+small. Further, these inference techniques usually fail completely if a column of data consists of values formatted in
+more than one way.
 
-The data type detection features in Code Accelerator come in handy in
-such scenarios. Not only does the data type detection convert data into the
-appropriate data type, the process is completely transparent. After generating code for the data type transformation/conversion, the user can then inspect or modify the code as desired: the system is no
+The data type detection features in Code Accelerator come in handy in such scenarios. Not only does the data type
+detection convert data into the appropriate data type, the process is completely transparent. After generating code for
+the data type transformation/conversion, the user can then inspect or modify the code as desired: the system is no
 longer a magical black box.
 
 ## Usage
@@ -61,9 +59,9 @@ Date:   <class 'str'>
 Value:  <class 'str'>
 ```
 
-You can see that the dates are in differing formats. Also, the `Value` column contains numbers formatted in three different ways: one
-with commas as the thousands separator, one without, and the last uses the scientific notation. With so much heterogeneity in the data,
-pandas is unable to automatically convert to the correct data types.
+You can see that the dates are in differing formats. Also, the `Value` column contains numbers formatted in three
+different ways: one with commas as the thousands separator, one without, and the last uses the scientific notation. With
+so much heterogeneity in the data, pandas is unable to automatically convert to the correct data types.
 
 To convert the columns into the correct data types, you can use the data type detection APIs in the PROSE Python SDK:
 
@@ -159,23 +157,19 @@ def coerce_types(df):
     })
 ```
 
-Observe that the generated code handles the various cases in the formatting
-of the data. Further, the generated code contains descriptive comments
-which make it easy for a user to modify the generated code to handle
-new and/or unseen formats in the data.
+Observe that the generated code handles the various cases in the formatting of the data. Further, the generated code
+contains descriptive comments which make it easy for a user to modify the generated code to handle new and/or unseen
+formats in the data.
 
 ## Inputs and Targets
-The data type detection APIs accept the following three forms of input: (1) A
-simple list, (2) a dictionary with string-valued keys and lists of strings
-as values, or (3) a pandas DataFrame with string-valued column identifiers.
+The data type detection APIs accept the following three forms of input: (1) A simple list, (2) a dictionary with
+string-valued keys and lists of strings as values, or (3) a pandas DataFrame with string-valued column identifiers.
 
-You can also specify the target for code generation. The data type
-detection API can generate code that will transform data contained in
-(1) a list, (2) a dictionary, (3) a pandas DataFrame, or (4) a PySpark
-DataFrame. Note that using a PySpark DataFrame as input is not supported. You can manually sample data from the PySpark DataFrame into a
-dictionary, or a pandas DataFrame. This sampled data may then be used as
-input to learn the data type transformation that can then be applied on the
-PySpark DataFrame.
+You can also specify the target for code generation. The data type detection API can generate code that will transform
+data contained in (1) a list, (2) a dictionary, (3) a pandas DataFrame, or (4) a PySpark DataFrame. Note that using a
+PySpark DataFrame as input is not supported. You can manually sample data from the PySpark DataFrame into a dictionary,
+or a pandas DataFrame. This sampled data may then be used as input to learn the data type transformation that can then
+be applied on the PySpark DataFrame.
 
 ## Supported types and restricting the set of detected types.
 
@@ -186,7 +180,9 @@ The data type detection APIs support detection of the following types:
 - Boolean values
 - String values
 
-Users can restrict the set of types detected by setting the `types_to_detect` property on an instance of `DetectTypesBuilder`. The property accepts assignment to a list of strings. The allowed values in the list include `'bool'`, `'boolean'`, `'numeric'`, `'number'`, `'datetime'`, `'string'` and `'text'`. For example:
+Users can restrict the set of types detected by setting the `types_to_detect` property on an instance of
+`DetectTypesBuilder`. The property accepts assignment to a list of strings. The allowed values in the list include
+`'bool'`, `'boolean'`, `'numeric'`, `'number'`, `'datetime'`, `'string'` and `'text'`. For example:
 
 ```python
 builder = cx.DetectTypesBuilder(df)
@@ -199,14 +195,11 @@ transformation_code = result.code()
 
 ## Limitations:
 
-- When a numeric column includes NA values, the default behavior of the
-code generated by the data type detection APIs is to return `None` in
-response to a value detected as an `NA` value. When used with a pandas
-DataFrame, any integer values intermixed with `None` in a column results in
-the entire column being represented using `numpy.float64` values. A user
-may workaround this by editing the code and choosing an appropriate
-non-`None` value to return when an `NA` value is converted.
+- When a numeric column includes NA values, the default behavior of the code generated by the data type detection APIs
+  is to return `None` in response to a value detected as an `NA` value. When used with a pandas DataFrame, any integer
+  values intermixed with `None` in a column results in the entire column being represented using `numpy.float64` values.
+  A user may workaround this by editing the code and choosing an appropriate non-`None` value to return when an `NA`
+  value is converted.
 
-- The data type detection APIs currently only process columns where the
-  data is string-valued. Non string-valued columns are simply returned
-  as-is, with no transformation applied.
+- The data type detection APIs currently only process columns where the data is string-valued. Non string-valued columns
+  are simply returned as-is, with no transformation applied.

--- a/prosepy/docs-ref-conceptual/intro.md
+++ b/prosepy/docs-ref-conceptual/intro.md
@@ -11,7 +11,9 @@ description: The Microsoft PROSE Code Accelerator SDK helps you quickly and accu
 
 # What is the Microsoft PROSE Code Accelerator SDK for Python?
 
-The Microsoft PROSE Code Accelerator SDK uses the power of [PROSE](https://microsoft.github.io/prose) to quickly and accurately generate Python code for common data preparation tasks. Code Accelerator includes functionality for data ingestion, data type correction, and pattern identification in string data.
+The Microsoft PROSE Code Accelerator SDK uses the power of [PROSE](https://microsoft.github.io/prose) to quickly and
+accurately generate Python code for common data preparation tasks. Code Accelerator includes functionality for data
+ingestion, data type correction, and pattern identification in string data.
 
 ## Requirements
 Code Accelerator runs on Python 3.5, 3.6, or 3.7 on Windows (32-bit or 64-bit), Linux (64-bit), and macOS.  It supports
@@ -65,9 +67,9 @@ takes a data frame of the same form as what was originally passed to the builder
  
  
 ## About the data method on learn result
-The `data()` method is intended to give a quick look at what the generated code will do.  For the input originally given to the
-builder, it will show what the output of running the generated code would be.  This way you can see if the code does
-what you want, and if not, provide different or additional information to the builder and try learning again.  
+The `data()` method is intended to give a quick look at what the generated code will do.  For the input originally given
+to the builder, it will show what the output of running the generated code would be.  This way you can see if the code
+does what you want, and if not, provide different or additional information to the builder and try learning again.  
 
 Since the provided data may be much larger than what you need for a quick check, the method takes an optional parameter
 of the number of output values to return.  For some learn results this is a number of a rows, for others it is just a

--- a/prosepy/docs-ref-conceptual/knownissues.md
+++ b/prosepy/docs-ref-conceptual/knownissues.md
@@ -1,6 +1,6 @@
 ---
 title: Known issues with the Microsoft PROSE Code Accelerator SDK - Python
-ms.date: 09/24/2018
+ms.date: 10/22/2018
 ms.topic: conceptual
 ms.service: non-product-specific
 author: simmdan
@@ -9,18 +9,11 @@ description: These are known issues with the current release of PROSE Code Accel
 ---
 
 # Known issues with the Microsoft PROSE Code Accelerator SDK
-The following are issues that the PROSE team is aware of with the 1.0.0 release of the Microsoft PROSE Code Accelerator SDK.  We are
-working to fix them in a future release.  If you encounter issues not on this list, please report them on the
-[prose-codeaccelerator GitHub repository](https://github.com/Microsoft/prose-codeaccelerator/issues).
-
-## ReadCsvBuilder
-- Only UTF-8 encoded files are supported.
-  
-## ReadFwfBuilder
-- Only UTF-8 encoded files are supported.
+The following are issues that the PROSE team is aware of with the 1.0.0 release of the Microsoft PROSE Code Accelerator
+SDK.  We are working to fix them in a future release.  If you encounter issues not on this list, please report them on
+the [prose-codeaccelerator GitHub repository](https://github.com/Microsoft/prose-codeaccelerator/issues).
   
 ## ReadJsonBuilder
-- Only UTF-8 encoded files are supported.
 
 ### Pandas:
 - If the JSON has a single top level array of values (e.g., `{"top": [1, 2]}`), pandas' `json_normalize` throws
@@ -80,4 +73,3 @@ working to fix them in a future release.  If you encounter issues not on this li
   Further, a bug in Python 3.6 causes dates earlier than `1970-01-02` to be handled incorrectly. To ensure reliable
   operation across platforms, time values without dates are represented with dates of `2000-01-01` in PySpark mode. The
   default date value for other targets remains `1900-01-01`, which is the default for Python.
-

--- a/prosepy/docs-ref-conceptual/readcsv.md
+++ b/prosepy/docs-ref-conceptual/readcsv.md
@@ -10,9 +10,10 @@ description: Learn how to analyze and pare delimited files with PROSE Code Accel
 
 # Read a CSV file with the Microsoft PROSE Code Accelerator SDK
 
-`ReadCsvBuilder` will analyze a given delimited text file (that has comma-separated values, or that uses other delimiters) and determine all the details about that file necessary to successfully parse it and
-produce a dataframe (either `pandas` or `pyspark`).  This includes the encoding, the delimiter, how many lines to skip at
-the beginning of the file, etc.
+`ReadCsvBuilder` will analyze a given delimited text file (that has comma-separated values, or that uses other
+delimiters) and determine all the details about that file necessary to successfully parse it and produce a dataframe
+(either `pandas` or `pyspark`).  This includes the encoding, the delimiter, how many lines to skip at the beginning of
+the file, etc.
 
 > [!NOTE]
 > `ReadCsvBuilder` explicitly reads columns as strings to prevent loss of precision during reading the data.

--- a/prosepy/docs-ref-conceptual/readfixedwidth.md
+++ b/prosepy/docs-ref-conceptual/readfixedwidth.md
@@ -12,11 +12,11 @@ description: Learn how to analyze a fixed-width file with PROSE Code Accelerator
 
 `ReadFwfBuilder` will analyze a fixed-width file and produce code to split the fields yielding a data frame.  When it is
 given only the fixed-width input file, Code Accelerator makes every effort to determine the boundaries between fields.
-Sometimes, however, this isn't possible. For example, if a file has two separate number fields placed directly next to one
-another, there might not be enough information to determine the boundary between them.  So,
-`ReadFwfBuilder` optionally also takes a file containing a description of the file schema.  This schema
-description does not have to be in an exact format; Code Accelerator will do its best to locate lists of fields and their column
-ranges and use that information to generate the code.
+Sometimes, however, this isn't possible. For example, if a file has two separate number fields placed directly next to
+one another, there might not be enough information to determine the boundary between them.  So, `ReadFwfBuilder`
+optionally also takes a file containing a description of the file schema.  This schema description does not have to be
+in an exact format; Code Accelerator will do its best to locate lists of fields and their column ranges and use that
+information to generate the code.
 
 > [!NOTE]
 > The `ReadFwfBuilder` explicitly reads columns as strings to prevent loss of precision during reading the data.

--- a/prosepy/docs-ref-conceptual/toc.yml
+++ b/prosepy/docs-ref-conceptual/toc.yml
@@ -13,6 +13,8 @@
       href: fixdatatypes.md
     - name: Find patterns in strings
       href: findpatterns.md
+  - name: Configuration
+    href: config.md
   - name: Known issues
     href: knownissues.md
   


### PR DESCRIPTION
This PR adds a page about configuration.  It also updates known issues and reformats a few of the other doc pages to word wrap at 120 columns.  The reformatting are in separate commits that only did re-wordwrapping--I didn't change any content in those commits.